### PR TITLE
feat: Secure Alchemy API key using environment variables

### DIFF
--- a/ZipTalesBlockchain/test_block_fetch.py
+++ b/ZipTalesBlockchain/test_block_fetch.py
@@ -1,7 +1,11 @@
 from web3 import Web3
+from dotenv import load_dotenv
+import os
 
+load_dotenv() # This loads the variables from .env
 # Connect to the Ethereum network
-w3 = Web3(Web3.HTTPProvider('https://eth-holesky.g.alchemy.com/v2/Imc1zDU8bNhQYJoW-7qvA'))
+ALCHEMY_API_KEY = os.getenv("ALCHEMY_API_KEY")
+w3 = Web3(Web3.HTTPProvider(f'https://eth-holesky.g.alchemy.com/v2/{ALCHEMY_API_KEY}'))
 
 # Get block by number
 block_number = 123456


### PR DESCRIPTION
This are the changes that i have made

- Moved the hardcoded Alchemy API key from `ZipTalesBlockchain/tests/integrations/block_fetcher/test_block_fetch.py` to a `.env` file.
- Modified `test_block_fetch.py` to load the Alchemy API key from the environment variable `ALCHEMY_API_KEY`.
- Ensured `.env` is listed in `.gitignore` to prevent it from being committed to the repository.

This enhancement improves security by preventing sensitive API keys from being hardcoded directly in the codebase.